### PR TITLE
Fix/selected coin state data

### DIFF
--- a/src/app/components/CoinSlide/index.tsx
+++ b/src/app/components/CoinSlide/index.tsx
@@ -17,7 +17,7 @@ interface Coin {
 }
 export default function CoinSlide({handleAddCoin, coinData, selected, currency} : {handleAddCoin: any, coinData: Coin, selected: boolean | undefined,currency: string,}) {
     return (
-        <li onClick={() => handleAddCoin(coinData.id)} className={`${selected ? "bg-[#6161D6]" : "bg-[#191925]"} rounded-xl flex p-3 hover:bg-[#6161D6] transition-all cursor-pointer`}>
+        <li onClick={() => handleAddCoin(coinData)} className={`${selected ? "bg-[#6161D6]" : "bg-[#191925]"} rounded-xl flex p-3 hover:bg-[#6161D6] transition-all cursor-pointer`}>
             <div className="flex items-center">
         <div className="w-8 h-8 mr-4">
             <Image width={36} height={36} className={`w-8 h-8 ${coinData.price_change_percentage_1h_in_currency > 0 ? "fill-green-500" : "fill-red-500"}`} src={coinData.image} alt="coin-image" />

--- a/src/app/components/CoinSlider/index.tsx
+++ b/src/app/components/CoinSlider/index.tsx
@@ -5,8 +5,6 @@ import "slick-carousel/slick/slick-theme.css";
 import Slider from "react-slick";
 import CoinSlide from "../CoinSlide";
 import {SliderNextArrow, SliderPrevArrow} from "../SliderArrows/SliderArrows";
-import { useEffect, useRef } from "react";
-import { fetchCoinList } from "@/app/lib/features/coinList/coinListSlice";
 import { fetchCoinData } from "@/app/lib/features/selectedCoins/selectedCoinsSlice";
 interface Coin {
     name: string;
@@ -31,12 +29,12 @@ const selectCurrency = (state) => state.currentCurrency;
     const sliderRef = useRef<Slider>(null);
     const currentCurrency = useAppSelector(selectCurrency);
     const dispatch = useAppDispatch();
-    const handleAddCoin = (id: string) => {
-        if (id === coin1?.id || id === coin2?.id || id === coin3?.id) {
-            dispatch({type: "selectedCoins/deselectCoin", payload: id});
+    const handleAddCoin = (coin: Coin) => {
+        if (coin.id === coin1?.id || coin.id === coin2?.id || coin.id === coin3?.id) {
+            dispatch({type: "selectedCoins/deselectCoin", payload: coin.id});
             return;
         }
-        dispatch(fetchCoinData(id));
+        dispatch(fetchCoinData(coin));
     };
     const next = () => {
         sliderRef.current.slickNext();
@@ -71,10 +69,6 @@ const selectCurrency = (state) => state.currentCurrency;
             }
         ]
     };
-    useEffect(() => {
-        dispatch(fetchCoinList());
-        dispatch(fetchCoinData("bitcoin"));
-    },[dispatch]);
     return (
         <div className="mb-10">
         <div className="mb-6">

--- a/src/app/components/CoinSlider/index.tsx
+++ b/src/app/components/CoinSlider/index.tsx
@@ -4,6 +4,7 @@ import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 import Slider from "react-slick";
 import CoinSlide from "../CoinSlide";
+import {useRef} from "react";
 import {SliderNextArrow, SliderPrevArrow} from "../SliderArrows/SliderArrows";
 import { fetchCoinData } from "@/app/lib/features/selectedCoins/selectedCoinsSlice";
 interface Coin {

--- a/src/app/components/Navbar/index.tsx
+++ b/src/app/components/Navbar/index.tsx
@@ -4,7 +4,6 @@ import Image from "next/image";
 import {useEffect, useState} from "react";
 import {usePathname} from "next/navigation";
 import { useAppSelector, useAppDispatch } from "@/app/lib/hooks";
-import { fetchCoinList } from "@/app/lib/features/coinList/coinListSlice";
 interface Coin  {
     id: string,
     symbol: string,
@@ -32,9 +31,6 @@ export default function Navbar() {
         const newCurrency: string = e.target.value;
         dispatch({type: "currency/change", payload: newCurrency});
     };
-    useEffect(() => {
-        dispatch(fetchCoinList("navbar"));
-    }, [currentCurrency, dispatch]);
     useEffect(() => {
         const timer = setTimeout(() => {
             setDebouncedCoinVal(coinSearchVal);

--- a/src/app/lib/features/coinList/coinListSlice.ts
+++ b/src/app/lib/features/coinList/coinListSlice.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { fetchCoinData } from "../selectedCoins/selectedCoinsSlice";
 interface CoinState {
     data: any[];
     isLoading: "idle" | "pending" | "success" | "failed";
@@ -8,8 +9,12 @@ interface CoinState {
 export const fetchCoinList = createAsyncThunk("coinList/getCoinList", async (arg, thunkApi) => {
     const {currentCurrency} = thunkApi.getState();
     const {coinList} = thunkApi.getState();
+    const {selectedCoins} = thunkApi.getState();
         const coinReq = await fetch(`https://api.coingecko.com/api/v3/coins/markets?x_cg_demo_api_key=CG-BGo9877QbEt6dRKHM2YL7z2q&vs_currency=${currentCurrency}&price_change_percentage=1h,24h,7d&per_page=${coinList.coinsToDisplay}`);
         const coinData = await coinReq.json();
+        if (selectedCoins.selectedCoins.length === 0) {
+            thunkApi.dispatch(fetchCoinData(coinData[0]));
+        }
         return coinData;
 });
 const initialState: CoinState = {

--- a/src/app/lib/features/selectedCoins/selectedCoinsSlice.ts
+++ b/src/app/lib/features/selectedCoins/selectedCoinsSlice.ts
@@ -6,13 +6,19 @@ interface State {
     error: boolean | string
 }
 const deselectCoin = createAction<string>("selectedCoins/deselectCoin");
-export const fetchCoinData = createAsyncThunk("selectedCoins/getCoinData", async (arg: string, thunkApi: any) => {
+export const fetchCoinData = createAsyncThunk("selectedCoins/getCoinData", async (arg: any, thunkApi: any) => {
     const {currentCurrency} = thunkApi.getState();
     const [currentTime, pastTime] = handleCoinDates();
-    const coinDataReq = await fetch(`https://api.coingecko.com/api/v3/coins/${arg}/market_chart/range?x_cg_demo_api_key=CG-BGo9877QbEt6dRKHM2YL7z2q&vs_currency=${currentCurrency}&from=${pastTime}&to=${currentTime}`);
+    const coinDataReq = await fetch(`https://api.coingecko.com/api/v3/coins/${arg.id}/market_chart/range?x_cg_demo_api_key=CG-BGo9877QbEt6dRKHM2YL7z2q&vs_currency=${currentCurrency}&from=${pastTime}&to=${currentTime}`);
     const coinData = await coinDataReq.json();
     const newCoin = {
-        id: arg,
+        id: arg.id,
+        name: arg.name,
+        symbol: arg.symbol,
+        // eslint-disable-next-line
+        total_volume: arg.total_volume,
+        // eslint-disable-next-line
+        current_price: arg.current_price,
         coinData
     };
     return newCoin;


### PR DESCRIPTION
Fixed the issue where navbar and the slider components dispatches a action to fetch the coin list causing two coins to appear in the selected charts. Also fixed the issue in the selected coin state to accept the coin itself instead of the coin id so the selected charts can display other data like price and total volume.