### PR TITLE
Feature/graph time duration state

### DIFF
--- a/src/app/lib/features/graphTimeDuration/graphTimeDurationSlice.ts
+++ b/src/app/lib/features/graphTimeDuration/graphTimeDurationSlice.ts
@@ -1,0 +1,32 @@
+import { createSlice, createAction} from "@reduxjs/toolkit";
+const oneDay = createAction("oneDay");
+const sevenDay = createAction("sevenDay");
+const oneMonth = createAction("oneMonth");
+const oneYear = createAction("oneYear");
+const maxTime = createAction("maxTime");
+const initialState = {
+    graphTimeDuration: 1,
+};
+const graphTimeDurationSlice = createSlice({
+    name: "graphTimeDuration",
+    initialState: initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder.addCase(oneDay, (state) => {
+            state.graphTimeDuration = 1;
+        });
+        builder.addCase(sevenDay, (state) => {
+            state.graphTimeDuration = 7;
+        });
+        builder.addCase(oneMonth, (state) => {
+            state.graphTimeDuration = 31;
+        });
+        builder.addCase(oneYear, (state) => {
+            state.graphTimeDuration = 365;
+        });
+        builder.addCase(maxTime, (state) => {
+            state.graphTimeDuration = 730;
+        });
+    }
+});
+export default graphTimeDurationSlice.reducer;

--- a/src/app/lib/features/graphTimeDuration/graphTimeDurationSlice.ts
+++ b/src/app/lib/features/graphTimeDuration/graphTimeDurationSlice.ts
@@ -1,9 +1,10 @@
 import { createSlice, createAction} from "@reduxjs/toolkit";
+const oneHour = createAction("oneHour");
 const oneDay = createAction("oneDay");
 const sevenDay = createAction("sevenDay");
+const fourteenDays = createAction("fourteenDays");
 const oneMonth = createAction("oneMonth");
 const oneYear = createAction("oneYear");
-const maxTime = createAction("maxTime");
 const initialState = {
     graphTimeDuration: 1,
 };
@@ -12,20 +13,23 @@ const graphTimeDurationSlice = createSlice({
     initialState: initialState,
     reducers: {},
     extraReducers: (builder) => {
+        builder.addCase(oneHour, (state) => {
+            state.graphTimeDuration = 0.0416666666666667;
+        });
         builder.addCase(oneDay, (state) => {
             state.graphTimeDuration = 1;
         });
         builder.addCase(sevenDay, (state) => {
             state.graphTimeDuration = 7;
         });
+        builder.addCase(fourteenDays, (state) => {
+            state.graphTimeDuration = 14;
+        });
         builder.addCase(oneMonth, (state) => {
             state.graphTimeDuration = 31;
         });
         builder.addCase(oneYear, (state) => {
             state.graphTimeDuration = 365;
-        });
-        builder.addCase(maxTime, (state) => {
-            state.graphTimeDuration = 730;
         });
     }
 });

--- a/src/app/lib/store.ts
+++ b/src/app/lib/store.ts
@@ -3,6 +3,7 @@ import coinListSlice from "./features/coinList/coinListSlice";
 import globalDataSlice from "./features/globalCoinData/globalDataSlice";
 import {currencyReducer} from "../lib/features/currency/currencySlice";
 import { themeReducer } from "./features/theme/themeSlice";
+import graphTimeDurationReducer from "./features/graphTimeDuration/graphTimeDurationSlice";
 import selectedCoinsSlice from "./features/selectedCoins/selectedCoinsSlice";
 export const makeStore = () => {
     return configureStore({
@@ -11,7 +12,8 @@ export const makeStore = () => {
             darkTheme: themeReducer,
             coinList: coinListSlice.reducer,
             globalData: globalDataSlice.reducer,
-            selectedCoins: selectedCoinsSlice.reducer
+            selectedCoins: selectedCoinsSlice.reducer,
+            graphTimeDuration: graphTimeDurationReducer
         },
     } );
 };


### PR DESCRIPTION
Added graph time duration state for the main selected coin charts so data can be seen across different durations of time e.g. 1 hour, 7 days.